### PR TITLE
Enhancement: Implement `ReleaseList::sortedByTagDescending()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ For a full diff see [`88cf670...main`][88cf670...main].
 
 - Added `EntryList::sortedByPullRequestAscending()` ([#294]), by [@localheinz]
 - Added `ReleaseList::sortedByTagAscending()` ([#295]), by [@localheinz]
+- Added `ReleaseList::sortedByTagDescending()` ([#296]), by [@localheinz]
 
 [88cf670...main]: https://github.com/ergebnis/keep-a-changelog/compare/88cf670...main
 
@@ -58,5 +59,6 @@ For a full diff see [`88cf670...main`][88cf670...main].
 [#293]: https://github.com/ergebnis/keep-a-changelog/pull/293
 [#294]: https://github.com/ergebnis/keep-a-changelog/pull/294
 [#295]: https://github.com/ergebnis/keep-a-changelog/pull/295
+[#296]: https://github.com/ergebnis/keep-a-changelog/pull/296
 
 [@localheinz]: https://github.com/localheinz

--- a/src/ReleaseList.php
+++ b/src/ReleaseList.php
@@ -77,4 +77,15 @@ final class ReleaseList
 
         return new self($sorted);
     }
+
+    public function sortedByTagDescending(): self
+    {
+        $sorted = $this->values;
+
+        \usort($sorted, static function (Release $a, Release $b): int {
+            return $b->tag()->compare($a->tag());
+        });
+
+        return new self($sorted);
+    }
 }

--- a/test/Unit/ReleaseListTest.php
+++ b/test/Unit/ReleaseListTest.php
@@ -107,4 +107,30 @@ final class ReleaseListTest extends Framework\TestCase
 
         self::assertEquals(ReleaseList::create(...$sorted), $mutated);
     }
+
+    public function testSortedByTagDescendingReturnsReleaseListWithReleasesSortedByTagDescending(): void
+    {
+        $faker = self::faker()->unique();
+
+        $values = \array_map(static function () use ($faker): Release {
+            return Release::create(
+                Tag::fromString($faker->semver()),
+                Changes::empty(),
+            );
+        }, \range(0, 4));
+
+        $releaseList = ReleaseList::create(...$values);
+
+        $mutated = $releaseList->sortedByTagDescending();
+
+        self::assertNotSame($releaseList, $mutated);
+
+        $sorted = $values;
+
+        \usort($sorted, static function (Release $a, Release $b): int {
+            return $b->tag()->compare($a->tag());
+        });
+
+        self::assertEquals(ReleaseList::create(...$sorted), $mutated);
+    }
 }


### PR DESCRIPTION
This pull request

- [x] implements `ReleaseList::sortedByTagDescending()`